### PR TITLE
Add Documentation For genMockFromModule

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -98,7 +98,7 @@ This is how `genMockFromModule` will mock the follwing data types:
 
 #### `Function`
 
-A new function will be created. The new function will have on formal parameters and when called will return `undefined`. This functionality also applies to `async functions`.
+A new function will be created. The new function will have no formal parameters and when called will return `undefined`. This functionality also applies to `async functions`.
 
 #### `Class`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -172,6 +172,8 @@ module.exports = {
 
 ```js
 // __tests__/example.test.js
+const example = jest.genMockFromModule('./example');
+
 test('should run example code', () => {
   // a new mocked function with 0 arity.
   expect(example.function.name).toEqual('foo');

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -100,7 +100,7 @@ Example:
 
 ```js
 // utils.js
-export default {
+module.exports = {
   authorize: () => {
     return 'token';
   },
@@ -110,7 +110,7 @@ export default {
 
 ```js
 // __tests__/genMockFromModule.test.js
-const utils = jest.genMockFromModule('../utils').default;
+const utils = jest.genMockFromModule('../utils');
 utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.genMockFromModule', () => {

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -188,7 +188,7 @@ test('should run example code', () => {
   // a new mocked class that maintains the original interface and mocks member functions.
   expect(example.class.constructor.name).toEqual('Bar');
   expect(example.class.foo.name).toEqual('foo');
-  // a deeploy cloned object that maintains the original interface and mocks it's values.
+  // a deeply cloned object that maintains the original interface and mocks it's values.
   expect(example.object).toEqual({
     baz: 'foo',
     bar: {

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -155,7 +155,7 @@ module.exports = {
     return a + b;
   },
   asyncFunction: async function asyncFoo(a, b) {
-    const result = (await a) + b;
+    const result = await a + b;
     return result;
   },
   class: new class Bar {

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -96,13 +96,31 @@ Given the name of a module, use the automatic mocking system to generate a mocke
 
 This is how `genMockFromModule` will mock the follwing data types:
 
-`Function`
+#### `Function`
 
-A new function will be created. The new function will have an arity of 0 and when called will return `undefined`.
+A new function will be created. The new function will have on formal parameters and when called will return `undefined`. This functionality also applies to `async functions`.
 
-`Async Function`
+#### `Class`
 
-This is useful when you want to create a [manual mock](ManualMocks.md) that extends the automatic mock's behavior.
+A new class will be created. The interface of the original class is maintained however all of the class member functions will be mocked.
+
+#### `Object`
+
+Objects are deeply cloned. Their interfaces are maintained and their values are mocked.
+
+#### `Array`
+
+The original array is ignored and a new empty array is created.
+
+#### `String`
+
+A new copy of the original stirng is mocked.
+
+#### `Number`
+
+A new copy of the original number is mocked.
+
+`genMockFromModule` is useful when you want to create a [manual mock](ManualMocks.md) that extends the automatic mock's behavior.
 
 Example:
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -154,6 +154,10 @@ module.exports = {
   function: function foo(a, b) {
     return a + b;
   },
+  asyncFunction: async function asyncFoo(a, b) {
+    const result = (await a) + b;
+    return result;
+  },
   class: new class Bar {
     foo() {}
   },
@@ -175,13 +179,16 @@ module.exports = {
 const example = jest.genMockFromModule('./example');
 
 test('should run example code', () => {
-  // a new mocked function with 0 arity.
+  // a new mocked function with no formal arguments.
   expect(example.function.name).toEqual('foo');
   expect(example.function.length).toEqual(0);
-  // a new mocked class that maintains the original interface and mocks member functions
+  // async functions are treated just like standard synchronous functions.
+  expect(example.asyncFunction.name).toEqual('asyncFoo');
+  expect(example.asyncFunction.length).toEqual(0);
+  // a new mocked class that maintains the original interface and mocks member functions.
   expect(example.class.constructor.name).toEqual('Bar');
   expect(example.class.foo.name).toEqual('foo');
-  // a deeploy cloned object that maintains the original interface and mocks it's values
+  // a deeploy cloned object that maintains the original interface and mocks it's values.
   expect(example.object).toEqual({
     baz: 'foo',
     bar: {
@@ -189,11 +196,11 @@ test('should run example code', () => {
       buzz: [],
     },
   });
-  // the original array is ignored and a new emtpy array is mocked
+  // the original array is ignored and a new emtpy array is mocked.
   expect(example.array.length).toEqual(0);
-  // a new copy of the original number
+  // a new copy of the original number.
   expect(example.number).toEqual(123);
-  // a new copy of the original string
+  // a new copy of the original string.
   expect(example.string).toEqual('baz');
 });
 ```

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -94,6 +94,14 @@ _Note: this method was previously called `autoMockOn`. When using `babel-jest`, 
 
 Given the name of a module, use the automatic mocking system to generate a mocked version of the module for you.
 
+This is how `genMockFromModule` will mock the follwing data types:
+
+`Function`
+
+A new function will be created. The new function will have an arity of 0 and when called will return `undefined`.
+
+`Async Function`
+
 This is useful when you want to create a [manual mock](ManualMocks.md) that extends the automatic mock's behavior.
 
 Example:

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -34,6 +34,7 @@ describe('moduleMocker', () => {
       expect(moduleMocker.getMetadata('banana').value).toEqual('banana');
       expect(moduleMocker.getMetadata(27).value).toEqual(27);
       expect(moduleMocker.getMetadata(false).value).toEqual(false);
+      expect(moduleMocker.getMetadata(Infinity).value).toEqual(Infinity);
     });
 
     it('does not retrieve metadata for arrays', () => {
@@ -56,6 +57,53 @@ describe('moduleMocker', () => {
       expect(metadata.value).toBeNull();
       expect(metadata.members).toBeUndefined();
       expect(metadata.type).toEqual('null');
+    });
+
+    it('retrieves metadata for ES6 classes', () => {
+      class ClassFooMock {
+        add(a, b) {
+          return a + b;
+        }
+      }
+      const metadata = moduleMocker.getMetadata(ClassFooMock);
+      expect(metadata.type).toEqual('function');
+      expect(metadata.name).toEqual('ClassFooMock');
+    });
+
+    it('retrieves synchronous function metadata', () => {
+      function functionFooMock() {}
+      const metadata = moduleMocker.getMetadata(functionFooMock);
+      expect(metadata.type).toEqual('function');
+      expect(metadata.name).toEqual('functionFooMock');
+    });
+
+    it('retrieves asynchronous function metadata', () => {
+      async function asyncFunctionFooMock() {}
+      const metadata = moduleMocker.getMetadata(asyncFunctionFooMock);
+      console.log(metadata);
+      expect(metadata.type).toEqual('function');
+      expect(metadata.name).toEqual('asyncFunctionFooMock');
+    });
+
+    it("retrieves metadata for object literals and it's members", () => {
+      const metadata = moduleMocker.getMetadata({
+        bar: 'two',
+        foo: 1,
+      });
+      expect(metadata.type).toEqual('object');
+      expect(metadata.members.bar.value).toEqual('two');
+      expect(metadata.members.bar.type).toEqual('constant');
+      expect(metadata.members.foo.value).toEqual(1);
+      expect(metadata.members.foo.type).toEqual('constant');
+    });
+
+    it('retrieves Date object metadata', () => {
+      const metadata = moduleMocker.getMetadata(Date);
+      expect(metadata.type).toEqual('function');
+      expect(metadata.name).toEqual('Date');
+      expect(metadata.members.now.name).toEqual('now');
+      expect(metadata.members.parse.name).toEqual('parse');
+      expect(metadata.members.UTC.name).toEqual('UTC');
     });
   });
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -60,10 +60,13 @@ describe('moduleMocker', () => {
     });
 
     it('retrieves metadata for ES6 classes', () => {
-      class ClassFooMock {}
-      const metadata = moduleMocker.getMetadata(ClassFooMock);
-      expect(metadata.type).toEqual('function');
-      expect(metadata.name).toEqual('ClassFooMock');
+      class ClassFooMock {
+        bar() {}
+      }
+      const fooInstance = new ClassFooMock();
+      const metadata = moduleMocker.getMetadata(fooInstance);
+      expect(metadata.type).toEqual('object');
+      expect(metadata.members.constructor.name).toEqual('ClassFooMock');
     });
 
     it('retrieves synchronous function metadata', () => {

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -61,9 +61,7 @@ describe('moduleMocker', () => {
 
     it('retrieves metadata for ES6 classes', () => {
       class ClassFooMock {
-        add(a, b) {
-          return a + b;
-        }
+        bar() {}
       }
       const metadata = moduleMocker.getMetadata(ClassFooMock);
       expect(metadata.type).toEqual('function');
@@ -80,7 +78,6 @@ describe('moduleMocker', () => {
     it('retrieves asynchronous function metadata', () => {
       async function asyncFunctionFooMock() {}
       const metadata = moduleMocker.getMetadata(asyncFunctionFooMock);
-      console.log(metadata);
       expect(metadata.type).toEqual('function');
       expect(metadata.name).toEqual('asyncFunctionFooMock');
     });

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -60,9 +60,7 @@ describe('moduleMocker', () => {
     });
 
     it('retrieves metadata for ES6 classes', () => {
-      class ClassFooMock {
-        bar() {}
-      }
+      class ClassFooMock {}
       const metadata = moduleMocker.getMetadata(ClassFooMock);
       expect(metadata.type).toEqual('function');
       expect(metadata.name).toEqual('ClassFooMock');


### PR DESCRIPTION
## Summary
Add more documentation around the auto-mocking functionality of `jest.genMockFromModule`. Especially in regards to how values are transformed and mocked by Jest. Resolves https://github.com/facebook/jest/issues/6812

## Test plan
Add a few tests to verify the assertions made by the documentation in `packages/jest-mock/src/__tests__/index.test.ts`.
